### PR TITLE
Form submission not successful

### DIFF
--- a/front/src/components/customer/newLaundryRequests/LaundryRequestForm.js
+++ b/front/src/components/customer/newLaundryRequests/LaundryRequestForm.js
@@ -30,6 +30,7 @@ function LaundryRequestForm(props) {
     const today = new Date();
     if (date < today.toLocaleDateString()) {
       setDateErrorMesssage("Date can not be in the past");
+      //Shujun: see comment
       return;
     } else {
       setDateErrorMesssage();


### PR DESCRIPTION
The LaundryREquestForm cannot be successfully submitted, it will always show "Date can not be in the past" with 404 error code. When refresh (not hard refresh) the page, it will crash.